### PR TITLE
Update v2022 11

### DIFF
--- a/array_wrapper.yyp
+++ b/array_wrapper.yyp
@@ -1,4 +1,7 @@
 {
+  "resourceType": "GMProject",
+  "resourceVersion": "1.6",
+  "name": "array_wrapper",
   "resources": [
     {"id":{"name":"scr_array_utils","path":"scripts/scr_array_utils/scr_array_utils.yy",},"order":16,},
     {"id":{"name":"obj_test","path":"objects/obj_test/obj_test.yy",},"order":14,},
@@ -10,13 +13,12 @@
     {"name":"iOS","path":"options/ios/options_ios.yy",},
     {"name":"Linux","path":"options/linux/options_linux.yy",},
     {"name":"macOS","path":"options/mac/options_mac.yy",},
-    {"name":"Main","path":"options/main/options_main.yy",},
     {"name":"tvOS","path":"options/tvos/options_tvos.yy",},
     {"name":"Windows","path":"options/windows/options_windows.yy",},
-    {"name":"Windows UWP","path":"options/windowsuap/options_windowsuap.yy",},
     {"name":"operagx","path":"options/operagx/options_operagx.yy",},
+    {"name":"Main","path":"options/main/options_main.yy",},
   ],
-  "isDnDProject": false,
+  "defaultScriptType": 1,
   "isEcma": false,
   "configs": {
     "name": "Default",
@@ -27,17 +29,13 @@
   ],
   "Folders": [],
   "AudioGroups": [
-    {"targets":-1,"resourceVersion":"1.3","name":"audiogroup_default","resourceType":"GMAudioGroup",},
+    {"resourceType":"GMAudioGroup","resourceVersion":"1.3","name":"audiogroup_default","targets":-1,},
   ],
   "TextureGroups": [
-    {"isScaled":true,"autocrop":true,"border":2,"mipsToGenerate":0,"groupParent":null,"targets":-1,"resourceVersion":"1.3","name":"Default","resourceType":"GMTextureGroup",},
+    {"resourceType":"GMTextureGroup","resourceVersion":"1.3","name":"Default","isScaled":true,"compressFormat":"bz2","loadType":"default","directory":"","autocrop":true,"border":2,"mipsToGenerate":0,"groupParent":null,"targets":-1,},
   ],
   "IncludedFiles": [],
   "MetaData": {
-    "IDEVersion": "2022.2.0.614",
+    "IDEVersion": "2022.11.0.54",
   },
-  "resourceVersion": "1.5",
-  "name": "array_wrapper",
-  "tags": [],
-  "resourceType": "GMProject",
 }

--- a/objects/obj_test/Create_0.gml
+++ b/objects/obj_test/Create_0.gml
@@ -5,36 +5,12 @@ arr1 = [0, 4, 2, 5, 3, 2];
 arr2 = [0, 4, 3, false, "", undefined, "olá"];
 arr3 = ["Hello", "World"];
 
-print(array_reverse(arr1));
-array_foreach_ext(arr1, function(array_item, sum_value, mult_value){ 
-													var _total = array_item * mult_value + sum_value; 
-													print(_total);
-												}, 2, 3);
-
-print(array_filter_ext(arr1, function(array_item, value_check){ return (array_item % value_check) == 0}, 2));
-
-print(array_map_ext(arr1, function(array_item, sum_value, mult_value){
-	return array_item * mult_value + sum_value;
-}, 2, 3)); 
-
-print(array_some_ext(arr3, function(arr_item, other_value){
-	return string_pos(other_value, arr_item) > 0;
-}, "A"));
-
-print(array_every_ext(arr3, function(arr_item, other_value){
-	return string_pos(other_value, arr_item) > 0;
-}, "d"));
-
-
-print(array_unique(arr1));
 
 print( array_join(arr1));
 print( array_join(arr1, "-"));
 
 println
 
-print(array_merge (arr1, arr2) );
-print(array_intersection(arr1, arr2));
 print(array_diff(arr1, arr2));
 
 print(array_shuffle(arr1));
@@ -45,25 +21,14 @@ print(array_get_max_value(arr1));
 print(array_get_min_value(arr1));
 print(array_get_random(arr1));
 print(array_last(arr1));
-print(array_reverse(arr1));
 print(array_compact(arr2));
 
-println
-array_foreach(arr1, function(value){ print(value); });
-println
 
 print(array_empty(arr1));
-print(array_find_index(arr1, 2));
 print(array_includes_amount(arr1, 0));
-
-print(array_filter(arr2, is_string));
-print(array_some(arr2, is_string));
-print(array_every(arr2, is_string));
-print(array_map(arr1, function(value){ return value % 2 == 0 } ));
 
 
 println
-print(array_reduce(arr1));
 print(array_join(arr3, " ", false));
 print(array_join(arr2, " ", true));
 

--- a/objects/obj_test/Create_0.gml
+++ b/objects/obj_test/Create_0.gml
@@ -1,58 +1,59 @@
+concat = function(){
+	var _str = "";
+	for(var i = 0; i < argument_count; i++){
+		_str += string(argument[i]) + " ";
+	}
+	
+	return _str;
+}
 #macro print show_debug_message
+#macro s print(concat( 
+#macro o ))
+
+
 #macro println print("")
+#macro finish game_end() exit
+
 
 arr1 = [0, 4, 2, 5, 3, 2];
 arr2 = [0, 4, 3, false, "", undefined, "olá"];
 arr3 = ["Hello", "World"];
 
+list = ds_list_create(); ds_list_add(list, 1, 6, 9, 10);
+var _arr_list = array_from_list(list);
+var _list = array_to_list(arr3);
 
-print( array_join(arr1));
-print( array_join(arr1, "-"));
+stack = ds_stack_create(); ds_stack_push(stack, 0, 1, 2, 3, 4, 6);
+var _arr_stack = array_from_stack(stack);
+var _stack = array_to_stack(arr2);
+
+queue = ds_queue_create(); ds_queue_enqueue(queue, 8, 4, 6, 2, 3);
+var _arr_queue = array_from_queue(queue);
+var _queue = array_to_queue(arr1)
+
+print(list)
+print(_arr_list)
+print(_list)
+
+print(stack)
+print(_arr_stack)
+print(_stack)
+
+print(queue)
+print(_arr_queue)
+print(_queue)
 
 println
 
-print(array_diff(arr1, arr2));
+s "Array before change", arr1 o 
 
-print(array_shuffle(arr1));
+array_shuffle(arr1);
+s "Shuffled:", arr1 o
 
-print(array_clone(arr2));
+array_swap(arr1, 0, 2);
+s "Swaped:", arr1 o
 
-print(array_get_max_value(arr1));
-print(array_get_min_value(arr1));
-print(array_get_random(arr1));
-print(array_last(arr1));
-print(array_compact(arr2));
+array_clear(arr1, 2);
+s "Cleared:", arr1 o
 
-
-print(array_empty(arr1));
-print(array_includes_amount(arr1, 0));
-
-
-println
-print(array_join(arr3, " ", false));
-print(array_join(arr2, " ", true));
-
-
-print(array_create_range(11));
-print(array_clear(arr1, 0));
-
-stack = ds_stack_create();
-ds_stack_push(stack, 0, 1, 2, 3, 4, 6);
-
-queue = ds_queue_create();
-ds_queue_enqueue(queue, 8, 4, 6, 2, 3);
-
-arr_stack = array_from_stack(stack)
-arr_queue = array_from_queue(queue);
-
-print(arr_stack);
-print(arr_queue);
-
-stack2 = array_to_stack(arr_stack);
-queue2 = array_to_queue(arr_queue);
-
-print(stack2);
-print(queue2);
-
-
-game_end();
+finish

--- a/objects/obj_test/obj_test.yy
+++ b/objects/obj_test/obj_test.yy
@@ -1,7 +1,11 @@
 {
+  "resourceType": "GMObject",
+  "resourceVersion": "1.0",
+  "name": "obj_test",
   "spriteId": null,
   "solid": false,
   "visible": true,
+  "managed": true,
   "spriteMaskId": null,
   "persistent": false,
   "parentObjectId": null,
@@ -18,7 +22,7 @@
   "physicsKinematic": false,
   "physicsShapePoints": [],
   "eventList": [
-    {"isDnD":false,"eventNum":0,"eventType":0,"collisionObjectId":null,"resourceVersion":"1.0","name":"","tags":[],"resourceType":"GMEvent",},
+    {"resourceType":"GMEvent","resourceVersion":"1.0","name":"","isDnD":false,"eventNum":0,"eventType":0,"collisionObjectId":null,},
   ],
   "properties": [],
   "overriddenProperties": [],
@@ -26,8 +30,4 @@
     "name": "array_wrapper",
     "path": "array_wrapper.yyp",
   },
-  "resourceVersion": "1.0",
-  "name": "obj_test",
-  "tags": [],
-  "resourceType": "GMObject",
 }

--- a/options/main/options_main.yy
+++ b/options/main/options_main.yy
@@ -1,4 +1,7 @@
 {
+  "resourceType": "GMMainOptions",
+  "resourceVersion": "1.4",
+  "name": "Main",
   "option_gameguid": "314dd303-be35-49f4-b3f5-428ebb0346a5",
   "option_gameid": "0",
   "option_game_speed": 60,
@@ -9,14 +12,9 @@
   "option_sci_usesci": false,
   "option_author": "",
   "option_collision_compatibility": true,
-  "option_copy_on_write_enabled": true,
-  "option_lastchanged": "13 February 2022 12:05:18",
+  "option_copy_on_write_enabled": false,
   "option_spine_licence": false,
   "option_template_image": "${base_options_dir}/main/template_image.png",
   "option_template_icon": "${base_options_dir}/main/template_icon.png",
   "option_template_description": null,
-  "resourceVersion": "1.4",
-  "name": "Main",
-  "tags": [],
-  "resourceType": "GMMainOptions",
 }

--- a/scripts/scr_array_utils/scr_array_utils.gml
+++ b/scripts/scr_array_utils/scr_array_utils.gml
@@ -1,8 +1,8 @@
 /// ARRAY UTILS | https://github.com/JeffersonJales/array_utils_gms2
 
 /// @description With this function you can shuffle the given array.
-/// @param {array} array The index of the array to shuffle
-/// @returns {array} Re-ordered array 
+/// @param {Array<Any>} array The index of the array to shuffle
+/// @returns {Array<Any>} Re-ordered array 
 function array_shuffle(array){
 	var _len = array_length(array), 
 		_random_index = 0,
@@ -20,10 +20,10 @@ function array_shuffle(array){
 }
 
 /// @description With this function you can swap the position of two values from the given array
-/// @param {array} array The index of the array
+/// @param {Array<Any>} array The index of the array
 /// @param {Real} index1 The first position to swap
 /// @param {Real} index2 The second position to swap
-/// @return {array} The index of the array
+/// @return {Array<Any>} The index of the array
 function array_swap(array, index1, index2){
 	var _value = array[index2];
 	array[index2] = array[index1];
@@ -32,8 +32,8 @@ function array_swap(array, index1, index2){
 }
 
 /// @description With this function you will copy all the given array to a new one
-/// @param {array} array The index of the array will be cloned
-/// @returns {array} An new array
+/// @param {Array<Any>} array The index of the array will be cloned
+/// @returns {Array} An new array
 function array_clone(array){
 	var _len = array_length(array);
 	var _arr = array_create(_len);
@@ -41,10 +41,10 @@ function array_clone(array){
 	return _arr;
 }
 
-/// @description With this function you can clear the given array with a specific value
-/// @param {array} array The index of the array to shuffle
-/// @param {ArgumentIdentity} The new value for all array elements
-/// @returns {array} A array index
+/// @description With this function you can clear the given array with a given value
+/// @param {Array<Any>} array The index of the array to shuffle
+/// @param {Any} value The new value for all array elements
+/// @returns {Array<Any>} A array index
 function array_clear(array, value){
 	var i = 0; repeat(array_length(array)){
 		array[i] = value;
@@ -55,7 +55,7 @@ function array_clear(array, value){
 }
 
 /// @description With this function you can retrieve the value from the given array; It also handles out of bound index (including negative)
-/// @param {array} array The index of the array
+/// @param {Array<Any>} array The index of the array
 /// @param {Real} index The index of the array to get the value from.
 /// @return {Any} The array index value OR undefined in case the length of the array is zero (0)
 function array_get_ext(array, index){
@@ -68,22 +68,8 @@ function array_get_ext(array, index){
 	return array[index];
 }
 
-/// @description With this function you can convert the given index value to a valid index to the given array
-/// @param {array} array The index of the array
-/// @param {Real} index The index position to convert
-/// @return {Any} undefined case it can't be converted OR the new valid index value
-function array_index_convert(array, index){
-	var _len = array_length(array)
-	if(_len == 0) return undefined;
-	
-	while(index < 0) index += _len;
-	while(index > _len) index -= _len;
-	
-	return index;
-}
-
 /// @description With this function you can check if the given index is inside of the bounds of the given array
-/// @param {array} array The index of the array
+/// @param {Array<Any>} array The index of the array
 /// @param {Real} index The index position to check
 /// @return {Bool} 
 function array_index_inside_bounds(array, index){
@@ -91,14 +77,14 @@ function array_index_inside_bounds(array, index){
 }
 
 /// @description With this function you can check if the given array is empty or not
-/// @param {array} array The index of the array
+/// @param {Array<Any>} array The index of the array
 /// @return {Bool}					
 function array_empty(array){
 	return array_length(array) == 0;	
 }
 
 /// @description With this function you can retrieve the position of the first entry of the given value on the given array 
-/// @param {array} array The index of the array
+/// @param {Array<Any>} array The index of the array
 /// @param {real} value The value to search on the given array
 /// @return {Any} undefined case don't find anything OR the position of the given value on the array (real)
 function array_find_index_simple(array, value){
@@ -113,9 +99,9 @@ function array_find_index_simple(array, value){
 }
 
 /// @description With this function you can retrieve all positions of the given value on the given array 
-/// @param {array} array The index of the array
+/// @param {Array<Any>} array The index of the array
 /// @param {real} value The value to search on the given array
-/// @return {array} The index of the array 
+/// @return {Array<Any>} The index of the array 
 function array_find_index_all(array, value){
 	var _list = ds_list_create();
 	var i = 0; repeat(array_length(array)){
@@ -131,9 +117,9 @@ function array_find_index_all(array, value){
 }
 
 /// @description With this function you can remove all entries of the a given value from a given array 
-/// @param {array} array The index of the array
+/// @param {Array<Any>} array The index of the array
 /// @param {Any} value The value to remove from the array
-/// @return {array} The index of the array 
+/// @return {Array<Any>} The index of the array 
 function array_remove(array, value){
 	var _indexes = array_find_index_all(array, value);
 	var i = 0; repeat(array_length(_indexes)){
@@ -145,7 +131,7 @@ function array_remove(array, value){
 }
 
 /// @description With this function you can check if the given array have the given value inside of it
-/// @param {array} array The index of the array
+/// @param {Array<Any>} array The index of the array
 /// @param {Any} value The value to check inside the array
 /// @return {Bool}
 function array_includes(array, value){
@@ -160,7 +146,7 @@ function array_includes(array, value){
 }
 
 /// @description With this function you can check the amount of times the given value appears in the given array
-/// @param {array} array The index of the array
+/// @param {Array<Any>} array The index of the array
 /// @param {Any} value The value to check inside the array
 /// @return {Real}
 function array_includes_amount(array, value){
@@ -174,7 +160,7 @@ function array_includes_amount(array, value){
 }
 
 /// @description With this function you can retrieve the maximun value inside of the given array
-/// @param {Array} array The index of the array
+/// @param {Array<Real>} array The index of the array
 /// @return {Any} Undefined case array length equals zero OR the max value inside of the array
 function array_get_max_value(array){
 	var _len = array_length(array);
@@ -190,7 +176,7 @@ function array_get_max_value(array){
 }
 
 /// @description With this function you can retrieve the minimum value inside of the given array
-/// @param {Array} array The index of the array 
+/// @param {Array<Real>} array The index of the array 
 /// @return {Any} Undefined case array length equals zero OR the max value inside of the array
 function array_get_min_value(array){
 	var _len = array_length(array);
@@ -206,7 +192,7 @@ function array_get_min_value(array){
 }
 
 /// @description With this function you can retrieve a random entry of the given array
-/// @param {Array} array The index of the array
+/// @param {Array<Any>} array The index of the array
 /// @return {Any} undefined in case length of the given array is zero OR the value of the a random entry of the given array
 function array_get_random(array){
 	var _len = array_length(array);
@@ -216,8 +202,8 @@ function array_get_random(array){
 }
 
 /// @description With this function you can retrieve the last entry of the given array
-/// @param {Array} array		The index of the array
-/// @return {Any}						undefined in case length of the given array is zero OR the value of the last entry given array
+/// @param {Array<Any>} array The index of the array
+/// @return {Any} undefined in case length of the given array is zero OR the value of the last entry given array
 function array_last(array){
 	var _len = array_length(array);
 	if(_len == 0) return undefined;
@@ -225,13 +211,11 @@ function array_last(array){
 	return array[_len - 1];	
 }
 
-
 /// @description With this function you can loop through the given array indices executing a given function; The function will be executed for every 
 /// entry of the array, receiving the value of the array index as an argument.
-/// @param {Array} array The index of the array
+/// @param {Array<Any>} array The index of the array
 /// @param {Function} func The function that will be called to every array entry
 /// @param {Any} args You can parse more arguments to the function, but the first argumento of the func will be always the array entry
-/// @return {N/A}
 function array_foreach_args(array, func, args){
 	var _arr_args = array_create(argument_count - 1);
 	
@@ -249,13 +233,12 @@ function array_foreach_args(array, func, args){
 	}
 }
 
-
 /// @description With this function you creates a new array with all elements that pass the test implemented by the provided function.
-/// @param {Array} array The index of the array
+/// @param {Array<Any>} array The index of the array
 /// @param {Function} filter_func Function is a predicate, to test each element of the array. Return a value that coerces to true to keep the element, or to false otherwise.
 /// It will receive the current element being processed in the array and have to return a boolean
 /// @param {Any} args You can parse more arguments to the function, but the first argument of the func will be always the array entry
-/// @return {Array} array A new array with the elements that pass the test. If no elements pass the test, an empty array will be returned.
+/// @return {Array<Any>} array A new array with the elements that pass the test. If no elements pass the test, an empty array will be returned.
 function array_filter_args(array, filter_func, args){
 	var _arr_args = array_create(argument_count - 1);
 	var i = 1; repeat(argument_count - 2){
@@ -281,7 +264,7 @@ function array_filter_args(array, filter_func, args){
 }
 
 /// @description With this function you tests whether at least one element in the array passes the test implemented by the provided function
-/// @param {Array} array The index of the array
+/// @param {Array<Any>} array The index of the array
 /// @param {Function} filter_func Function is a predicate, to test each element of the array. Return a value that coerces to true to keep the element, or to false otherwise.
 /// It will receive the current element being processed in the array and have to return a boolean
 /// @param {Any} args You can parse more arguments to the function, but the first argument of the func will be always the array entry
@@ -298,7 +281,7 @@ function array_any_args(array, filter_func, args){
 }
 
 /// @description With this function you tests whether all elements in the array pass the test implemented by the provided function
-/// @param {Array} array The index of the array
+/// @param {Array<Any>} array The index of the array
 /// @param {Function} filter_func Function is a predicate, to test each element of the array. Return a value that coerces to true to keep the element, or to false otherwise.
 /// It will receive the current element being processed in the array and have to return a boolean
 /// @param {Any} args You can parse more arguments to the function, but the first argument of the func will be always the array entry
@@ -315,10 +298,10 @@ function array_all_args(array, filter_func, args){
 }
 
 /// @description With this function you creates a new array populated with the results of calling a provided function on every element in the calling array.
-/// @param {Array} array The index of the array
+/// @param {Array<Any>} array The index of the array
 /// @param {Function} map_func Function that is called for every element of the given array. Each time it executes, the returned value is added to new array.
 /// @param {Any} args You can parse more arguments to the function, but the first argument of the func will be always the array entry
-/// @return {Array} An array index
+/// @return {Array<Any>} An array index
 function array_map_args(array, map_func, args){
 	var _arr_args = array_create(argument_count - 1);
 	
@@ -332,17 +315,18 @@ function array_map_args(array, map_func, args){
 	
 	var _len = array_length(array);
 	var _array_map = array_create(_len);
-	var i = 0; repeat(_len){
-		_arr_args[0] = array[i]
-		_array_map[i] = script_execute_ext(_func_index, _arr_args);
-		i++;
+	
+	var f = 0; repeat(_len){
+		_arr_args[0] = array[f]
+		_array_map[f] = script_execute_ext(_func_index, _arr_args);
+		f++;
 	}
 	
 	return _array_map;
 }
 
 /// @description With this function you can retrieve the all elements of the given array in a string format
-/// @param {Array} array The index of the array
+/// @param {Array<Any>} array The index of the array
 /// @param {String} sep A string symbol to sep every entry
 /// @param {Bool} show_bound An flag to add the array bounds on the final string
 /// @return {String} All elements on a string
@@ -364,7 +348,7 @@ function array_join(array, sep = "", show_bound = false){
 }
 
 /// @description With this function you create a new array from the given array removing those values: false, zero (0), ""  and undefined 
-/// @param {Array} array The index of the array
+/// @param {Array<Any>} array The index of the array
 /// @return {Array} The index of the array
 function array_compact(array){
 	var _func = function(val){
@@ -377,7 +361,7 @@ function array_compact(array){
 /// @description With this function you create an array where is length is the given size
 /// Also, all array indices will be initialized with it indice position. 
 /// @param {Real} size The size of the array to create.
-/// @return {Array} The index of the array
+/// @return {Array<Real>, Undefined} The index of the array
 function array_create_range(size = 1){
 	if(size < 0) return undefined;
 	
@@ -391,9 +375,9 @@ function array_create_range(size = 1){
 }
 
 /// @description With this function you create a new array where it elements will be all the elements of the first given array that doesn't exists in the second given array
-/// @param {Array} array1 The index of the first array
-/// @param {Array} array2 The index of the second array
-/// @return {Array} The index of the array
+/// @param {Array<Any>} array1 The index of the first array
+/// @param {Array<Any>} array2 The index of the second array
+/// @return {Array<Any>} The index of the array
 function array_diff(array1, array2){
 	var _list = ds_list_create();
 	
@@ -411,8 +395,8 @@ function array_diff(array1, array2){
 }
 
 /// @description With this function you create a new ds_list from an array
-/// @param {array} array The index of the array
-/// @return {Id.DsList} The index of the list
+/// @param {Array<Any>} array The index of the array
+/// @return {Id.DsList<Any>} The index of the list
 function array_to_list(array){
 	var _list = ds_list_create();
 	var i = 0; repeat(array_length(array)){
@@ -424,8 +408,8 @@ function array_to_list(array){
 }
 
 /// @description With this function you create an array from a list (ds_list)
-/// @param {Id.DsList} ds_list The index of the list
-/// @return {array} The index of the array 
+/// @param {Id.DsList<Any>} ds_list The index of the list
+/// @return {Array<Any>} The index of the array 
 function array_from_list(ds_list){
 	var _len = ds_list_size(ds_list);
 	var array = array_create( _len );	
@@ -439,8 +423,8 @@ function array_from_list(ds_list){
 }
 
 /// @description With this function you create a new ds_stack from an array
-/// @param {array} array The index of the array
-/// @return {Id.DsStack} The index of the stack
+/// @param {Array<Any>} array The index of the array
+/// @return {Id.DsStack<Any>} The index of the stack
 function array_to_stack(array){
 	var _stack = ds_stack_create();
 	var i = 0; repeat(array_length(array)){
@@ -451,8 +435,8 @@ function array_to_stack(array){
 }
 
 /// @description With this function you create an array from a stack (ds_stack)
-/// @param {Id.DsStack} ds_stack The index of the stack
-/// @return {array} The index of the array
+/// @param {Id.DsStack<Any>} ds_stack The index of the stack
+/// @return {Array<Any>} The index of the array
 function array_from_stack(ds_stack){
 	var _len = ds_stack_size(ds_stack);
 	var _arr = array_create(_len);
@@ -470,8 +454,8 @@ function array_from_stack(ds_stack){
 }
 
 /// @description With this function you create a ds_queue from an array
-/// @param {array} array The index of the array
-/// @return {Id.DsQueue} The index of the queue
+/// @param {Array<Any>} array The index of the array
+/// @return {Id.DsQueue<Any>} The index of the queue
 function array_to_queue(array){
 	var _queue = ds_queue_create();
 	var i = 0; repeat(array_length(array)){
@@ -483,8 +467,8 @@ function array_to_queue(array){
 }
 
 /// @description With this function you create a new ds_queue from an array
-/// @param {Id.DsQueue} ds_queue The Index of the queue
-/// @return {array} The index of the array 
+/// @param {Id.DsQueue<Any>} ds_queue The Index of the queue
+/// @return {Array<Any>} The index of the array 
 function array_from_queue(ds_queue){
 	var _len = ds_queue_size(ds_queue);
 	var _arr = array_create(_len);

--- a/scripts/scr_array_utils/scr_array_utils.gml
+++ b/scripts/scr_array_utils/scr_array_utils.gml
@@ -1,12 +1,12 @@
 /// ARRAY UTILS | https://github.com/JeffersonJales/array_utils_gms2
 
 /// @description With this function you can shuffle the given array.
-/// @param {array} array		The index of the array to shuffle
-/// @returns {array}				Re-ordered array 
+/// @param {array} array The index of the array to shuffle
+/// @returns {array} Re-ordered array 
 function array_shuffle(array){
 	var _len = array_length(array), 
-			_random_index = 0,
-			_value;
+		_random_index = 0,
+		_value;
 			
 	while(_len != 0){
 		_random_index = irandom(--_len);
@@ -19,31 +19,11 @@ function array_shuffle(array){
 	return array;
 }
 
-/// @description With this function you can reverse the array indices; The first element becomes the last, and the last array element becomes the first.
-/// @param {array} array		The index of the array to reverse
-/// @returns {array}				Reversed array
-function array_reverse(array){
-	var _len = array_length(array);
-	var _value = 0, _last_index = 0;
-
-	var i = 0; repeat( floor(_len * 0.5) ){
-		_value = array[i];
-		_last_index = _len - i - 1;
-		
-		array[i] = array[_last_index];
-		array[_last_index] = _value;
-		
-		i++;
-	}
-	
-	return array;
-}
-
 /// @description With this function you can swap the position of two values from the given array
-/// @param {array} array		The index of the array
-/// @param {Real} index1		The first position to swap
-/// @param {Real} index2		The second position to swap
-/// @return {array}					The index of the array
+/// @param {array} array The index of the array
+/// @param {Real} index1 The first position to swap
+/// @param {Real} index2 The second position to swap
+/// @return {array} The index of the array
 function array_swap(array, index1, index2){
 	var _value = array[index2];
 	array[index2] = array[index1];
@@ -52,8 +32,8 @@ function array_swap(array, index1, index2){
 }
 
 /// @description With this function you will copy all the given array to a new one
-/// @param {array} array		The index of the array will be cloned
-/// @returns {array}				An new array
+/// @param {array} array The index of the array will be cloned
+/// @returns {array} An new array
 function array_clone(array){
 	var _len = array_length(array);
 	var _arr = array_create(_len);
@@ -62,9 +42,9 @@ function array_clone(array){
 }
 
 /// @description With this function you can clear the given array with a specific value
-/// @param {array} array				The index of the array to shuffle
-/// @param {ArgumentIdentity}		The new value for all array elements
-/// @returns {array}						A array index
+/// @param {array} array The index of the array to shuffle
+/// @param {ArgumentIdentity} The new value for all array elements
+/// @returns {array} A array index
 function array_clear(array, value){
 	var i = 0; repeat(array_length(array)){
 		array[i] = value;
@@ -75,53 +55,53 @@ function array_clear(array, value){
 }
 
 /// @description With this function you can retrieve the value from the given array; It also handles out of bound index (including negative)
-/// @param {array} array		The index of the array
-/// @param {Real} index			The index of the array to get the value from.
-/// @return {Any}						The array index value OR undefined in case the length of the array is zero (0)
+/// @param {array} array The index of the array
+/// @param {Real} index The index of the array to get the value from.
+/// @return {Any} The array index value OR undefined in case the length of the array is zero (0)
 function array_get_ext(array, index){
 	var _len = array_length(array);
 	if(_len == 0) return undefined;
 	
-	while(index < 0)		index += _len;
+	while(index < 0) index += _len;
 	while(index > _len) index -= _len;
 	
 	return array[index];
 }
 
-/// @description With this function you can check if the given index is inside of the bounds of the given array
-/// @param {array} array		The index of the array
-/// @param {Real} index			The index position to check
-/// @return {Bool} 
-function array_index_inside_bounds(array, index){
-	return index >= 0 && array_length(array) > index; 
-}
-
 /// @description With this function you can convert the given index value to a valid index to the given array
-/// @param {array} array		The index of the array
-/// @param {Real} index			The index position to convert
-/// @return {Any}						undefined case it can't be converted OR the new valid index value
+/// @param {array} array The index of the array
+/// @param {Real} index The index position to convert
+/// @return {Any} undefined case it can't be converted OR the new valid index value
 function array_index_convert(array, index){
 	var _len = array_length(array)
 	if(_len == 0) return undefined;
 	
-	while(index < 0)		index += _len;
+	while(index < 0) index += _len;
 	while(index > _len) index -= _len;
 	
 	return index;
 }
 
+/// @description With this function you can check if the given index is inside of the bounds of the given array
+/// @param {array} array The index of the array
+/// @param {Real} index The index position to check
+/// @return {Bool} 
+function array_index_inside_bounds(array, index){
+	return index >= 0 && array_length(array) > index; 
+}
+
 /// @description With this function you can check if the given array is empty or not
-/// @param {array} array		The index of the array
+/// @param {array} array The index of the array
 /// @return {Bool}					
 function array_empty(array){
 	return array_length(array) == 0;	
 }
 
 /// @description With this function you can retrieve the position of the first entry of the given value on the given array 
-/// @param {array} array		The index of the array
-/// @param {real} value			The value to search on the given array
-/// @return {Any}						undefined case don't find anything OR the position of the given value on the array (real)
-function array_find_index(array, value){
+/// @param {array} array The index of the array
+/// @param {real} value The value to search on the given array
+/// @return {Any} undefined case don't find anything OR the position of the given value on the array (real)
+function array_find_index_simple(array, value){
 	var i = 0; repeat(array_length(array)){
 		if(array[i] == value) 
 			return i;
@@ -133,14 +113,16 @@ function array_find_index(array, value){
 }
 
 /// @description With this function you can retrieve all positions of the given value on the given array 
-/// @param {array} array		The index of the array
-/// @param {real} value			The value to search on the given array
-/// @return {array}					The index of the array 
+/// @param {array} array The index of the array
+/// @param {real} value The value to search on the given array
+/// @return {array} The index of the array 
 function array_find_index_all(array, value){
 	var _list = ds_list_create();
 	var i = 0; repeat(array_length(array)){
 		if(array[i] == value) 
 			ds_list_add(_list, i);	
+			
+		i++;
 	}
 	
 	var _arr = array_from_list(_list);
@@ -149,9 +131,9 @@ function array_find_index_all(array, value){
 }
 
 /// @description With this function you can remove all entries of the a given value from a given array 
-/// @param {array} array		The index of the array
-/// @param {Any} value			The value to remove from the array
-/// @return {array}					The index of the array 
+/// @param {array} array The index of the array
+/// @param {Any} value The value to remove from the array
+/// @return {array} The index of the array 
 function array_remove(array, value){
 	var _indexes = array_find_index_all(array, value);
 	var i = 0; repeat(array_length(_indexes)){
@@ -163,8 +145,8 @@ function array_remove(array, value){
 }
 
 /// @description With this function you can check if the given array have the given value inside of it
-/// @param {array} array		The index of the array
-/// @param {Any} value			The value to check inside the array
+/// @param {array} array The index of the array
+/// @param {Any} value The value to check inside the array
 /// @return {Bool}
 function array_includes(array, value){
 	var i = 0; repeat(array_length(array)){
@@ -178,8 +160,8 @@ function array_includes(array, value){
 }
 
 /// @description With this function you can check the amount of times the given value appears in the given array
-/// @param {array} array		The index of the array
-/// @param {Any} value			The value to check inside the array
+/// @param {array} array The index of the array
+/// @param {Any} value The value to check inside the array
 /// @return {Real}
 function array_includes_amount(array, value){
 	var _amount = 0;
@@ -192,8 +174,8 @@ function array_includes_amount(array, value){
 }
 
 /// @description With this function you can retrieve the maximun value inside of the given array
-/// @param {Array} array			The index of the array
-/// @return {Any}							Undefined case array length equals zero OR the max value inside of the array
+/// @param {Array} array The index of the array
+/// @return {Any} Undefined case array length equals zero OR the max value inside of the array
 function array_get_max_value(array){
 	var _len = array_length(array);
 	if(_len == 0) return undefined;
@@ -208,8 +190,8 @@ function array_get_max_value(array){
 }
 
 /// @description With this function you can retrieve the minimum value inside of the given array
-/// @param {Array} array			The index of the array 
-/// @return {Any}							Undefined case array length equals zero OR the max value inside of the array
+/// @param {Array} array The index of the array 
+/// @return {Any} Undefined case array length equals zero OR the max value inside of the array
 function array_get_min_value(array){
 	var _len = array_length(array);
 	if(_len == 0) return undefined;
@@ -224,8 +206,8 @@ function array_get_min_value(array){
 }
 
 /// @description With this function you can retrieve a random entry of the given array
-/// @param {Array} array			The index of the array
-/// @return {Any}							undefined in case length of the given array is zero OR the value of the a random entry of the given array
+/// @param {Array} array The index of the array
+/// @return {Any} undefined in case length of the given array is zero OR the value of the a random entry of the given array
 function array_get_random(array){
 	var _len = array_length(array);
 	if(_len == 0) return undefined;
@@ -243,24 +225,14 @@ function array_last(array){
 	return array[_len - 1];	
 }
 
-/// @description With this function you can loop through the given array indices executing a given function; The function will be executed for every 
-/// entry of the array, receiving the value of the array index as an argument.
-/// @param {Array} array				The index of the array
-/// @param {Function} func			The function that will be called to every array entry
-/// @return {N/A}
-function array_foreach(array, func){
-	var i = 0; repeat(array_length(array)){
-		func(array[i++]);	
-	}
-}
 
 /// @description With this function you can loop through the given array indices executing a given function; The function will be executed for every 
 /// entry of the array, receiving the value of the array index as an argument.
-/// @param {Array} array				The index of the array
-/// @param {Function} func			The function that will be called to every array entry
-/// @param {Any} args						You can parse more arguments to the function, but the first argumento of the func will be always the array entry
+/// @param {Array} array The index of the array
+/// @param {Function} func The function that will be called to every array entry
+/// @param {Any} args You can parse more arguments to the function, but the first argumento of the func will be always the array entry
 /// @return {N/A}
-function array_foreach_ext(array, func, args){
+function array_foreach_args(array, func, args){
 	var _arr_args = array_create(argument_count - 1);
 	
 	var i = 1; repeat(argument_count - 2){
@@ -277,40 +249,20 @@ function array_foreach_ext(array, func, args){
 	}
 }
 
-/// @description With this function you creates a new array with all elements that pass the test implemented by the provided function.
-/// @param {Array} array						The index of the array
-/// @param {Function} filter_func		Function is a predicate, to test each element of the array. Return a value that coerces to true to keep the element, or to false otherwise.
-/// It will receive the current element being processed in the array and have to return a boolean
-/// @return {Array} array						A new array with the elements that pass the test. If no elements pass the test, an empty array will be returned.
-function array_filter(array, filter_func){
-	var _len = array_length(array);
-	var _list = ds_list_create();
-	
-	var i = 0; repeat(_len){
-		if(filter_func(array[i])) 
-			ds_list_add(_list, array[i]);	
-	
-		i++;
-	}
-	
-	var _arr = array_from_list(_list);
-	ds_list_destroy(_list);
-	return _arr;
-}
 
 /// @description With this function you creates a new array with all elements that pass the test implemented by the provided function.
-/// @param {Array} array						The index of the array
-/// @param {Function} filter_func		Function is a predicate, to test each element of the array. Return a value that coerces to true to keep the element, or to false otherwise.
+/// @param {Array} array The index of the array
+/// @param {Function} filter_func Function is a predicate, to test each element of the array. Return a value that coerces to true to keep the element, or to false otherwise.
 /// It will receive the current element being processed in the array and have to return a boolean
-/// @param {Any} args								You can parse more arguments to the function, but the first argument of the func will be always the array entry
-/// @return {Array} array						A new array with the elements that pass the test. If no elements pass the test, an empty array will be returned.
-function array_filter_ext(array, filter_func, args){
+/// @param {Any} args You can parse more arguments to the function, but the first argument of the func will be always the array entry
+/// @return {Array} array A new array with the elements that pass the test. If no elements pass the test, an empty array will be returned.
+function array_filter_args(array, filter_func, args){
 	var _arr_args = array_create(argument_count - 1);
 	var i = 1; repeat(argument_count - 2){
 		_arr_args[i] = argument[i + 1]
 		i++;
 	}
-	var _func				= method(self, filter_func);
+	var _func = method(self, filter_func);
 	var _func_index = method_get_index(_func);
 	
 	var _len = array_length(array);
@@ -329,24 +281,12 @@ function array_filter_ext(array, filter_func, args){
 }
 
 /// @description With this function you tests whether at least one element in the array passes the test implemented by the provided function
-/// @param {Array} array						The index of the array
-/// @param {Function} filter_func		Function is a predicate, to test each element of the array. Return a value that coerces to true to keep the element, or to false otherwise.
+/// @param {Array} array The index of the array
+/// @param {Function} filter_func Function is a predicate, to test each element of the array. Return a value that coerces to true to keep the element, or to false otherwise.
 /// It will receive the current element being processed in the array and have to return a boolean
-/// @return {Bool}									Return true if at least one element pass the test
-function array_some(array, filter_func){
-	if(array_length(array) == 0) return undefined;
-	
-	var _arr_filter = array_filter(array, filter_func);
-	return array_length(_arr_filter) > 0;
-}
-
-/// @description With this function you tests whether at least one element in the array passes the test implemented by the provided function
-/// @param {Array} array						The index of the array
-/// @param {Function} filter_func		Function is a predicate, to test each element of the array. Return a value that coerces to true to keep the element, or to false otherwise.
-/// It will receive the current element being processed in the array and have to return a boolean
-/// @param {Any} args								You can parse more arguments to the function, but the first argument of the func will be always the array entry
-/// @return {Bool}									Return true if at least one element pass the test
-function array_some_ext(array, filter_func, args){
+/// @param {Any} args You can parse more arguments to the function, but the first argument of the func will be always the array entry
+/// @return {Bool} Return true if at least one element pass the test
+function array_any_args(array, filter_func, args){
 	var _arr_args = array_create(argument_count);
 	var i = 0; repeat(argument_count){
 		_arr_args[i] = argument[i]
@@ -358,23 +298,12 @@ function array_some_ext(array, filter_func, args){
 }
 
 /// @description With this function you tests whether all elements in the array pass the test implemented by the provided function
-/// @param {Array} array							The index of the array
-/// @param {Function} filter_func			Function is a predicate, to test each element of the array. Return a value that coerces to true to keep the element, or to false otherwise.
+/// @param {Array} array The index of the array
+/// @param {Function} filter_func Function is a predicate, to test each element of the array. Return a value that coerces to true to keep the element, or to false otherwise.
 /// It will receive the current element being processed in the array and have to return a boolean
-/// @return {Bool}										Returns true if all elements pass the test
-function array_every(array, filter_func){
-	var _arr_filter = array_filter(array, filter_func);
-	return array_length(array) == array_length(_arr_filter);
-}
-
-
-/// @description With this function you tests whether all elements in the array pass the test implemented by the provided function
-/// @param {Array} array						The index of the array
-/// @param {Function} filter_func		Function is a predicate, to test each element of the array. Return a value that coerces to true to keep the element, or to false otherwise.
-/// It will receive the current element being processed in the array and have to return a boolean
-/// @param {Any} args								You can parse more arguments to the function, but the first argument of the func will be always the array entry
-/// @return {Bool}									Returns true if all elements pass the test
-function array_every_ext(array, filter_func, args){
+/// @param {Any} args You can parse more arguments to the function, but the first argument of the func will be always the array entry
+/// @return {Bool} Returns true if all elements pass the test
+function array_all_args(array, filter_func, args){
 	var _arr_args = array_create(argument_count);
 	var i = 0; repeat(argument_count){
 		_arr_args[i] = argument[i]
@@ -386,35 +315,20 @@ function array_every_ext(array, filter_func, args){
 }
 
 /// @description With this function you creates a new array populated with the results of calling a provided function on every element in the calling array.
-/// @param {Array} array					The index of the array
-/// @param {Function} map_func		Function that is called for every element of the given array. Each time it executes, the returned value is added to new array.
-/// @return {Array}								An array index
-function array_map(array, map_func){
-	var _len = array_length(array);
-	var _array_map = array_create(_len);
-	
-	var i = 0; repeat(_len){
-		_array_map[i] = map_func(array[i]);
-		i++;
-	}
-	
-	return _array_map;
-}
-
-/// @description With this function you creates a new array populated with the results of calling a provided function on every element in the calling array.
-/// @param {Array} array					The index of the array
-/// @param {Function} map_func		Function that is called for every element of the given array. Each time it executes, the returned value is added to new array.
-/// @param {Any} args							You can parse more arguments to the function, but the first argument of the func will be always the array entry
-/// @return {Array}								An array index
-function array_map_ext(array, map_func, args){
+/// @param {Array} array The index of the array
+/// @param {Function} map_func Function that is called for every element of the given array. Each time it executes, the returned value is added to new array.
+/// @param {Any} args You can parse more arguments to the function, but the first argument of the func will be always the array entry
+/// @return {Array} An array index
+function array_map_args(array, map_func, args){
 	var _arr_args = array_create(argument_count - 1);
+	
 	var i = 1; repeat(argument_count - 2){
 		_arr_args[i] = argument[i + 1]
 		i++;
 	}
-	var _func				= method(self, map_func);
-	var _func_index = method_get_index(_func);
 	
+	var _func = method(self, map_func);
+	var _func_index = method_get_index(_func);
 	
 	var _len = array_length(array);
 	var _array_map = array_create(_len);
@@ -427,23 +341,11 @@ function array_map_ext(array, map_func, args){
 	return _array_map;
 }
 
-/// @description With this function you can retrieve the sum of all elements of the given array
-/// @param {Array} array					The index of the array
-/// @return {Real}								The total sum
-function array_reduce(array_real){
-	var _sum = 0;
-	var i = 0; repeat(array_length(array_real)){
-		_sum += array_real[i++];
-	}
-	
-	return _sum;
-}
-
 /// @description With this function you can retrieve the all elements of the given array in a string format
-/// @param {Array} array					The index of the array
-/// @param {String} sep						A string symbol to sep every entry
-/// @param {Bool} show_bound			An flag to add the array bounds on the final string
-/// @return {String}							All elements on a string
+/// @param {Array} array The index of the array
+/// @param {String} sep A string symbol to sep every entry
+/// @param {Bool} show_bound An flag to add the array bounds on the final string
+/// @return {String} All elements on a string
 function array_join(array, sep = "", show_bound = false){
 	var _str = "", _current;
 	var _len = array_length(array)
@@ -462,8 +364,8 @@ function array_join(array, sep = "", show_bound = false){
 }
 
 /// @description With this function you create a new array from the given array removing those values: false, zero (0), ""  and undefined 
-/// @param {Array} array					The index of the array
-/// @return {Array}								The index of the array
+/// @param {Array} array The index of the array
+/// @return {Array} The index of the array
 function array_compact(array){
 	var _func = function(val){
 		return !( val == false ||  val == "" || val == undefined )
@@ -474,8 +376,8 @@ function array_compact(array){
 
 /// @description With this function you create an array where is length is the given size
 /// Also, all array indices will be initialized with it indice position. 
-/// @param {Real} size						The size of the array to create.
-/// @return {Array}								The index of the array
+/// @param {Real} size The size of the array to create.
+/// @return {Array} The index of the array
 function array_create_range(size = 1){
 	if(size < 0) return undefined;
 	
@@ -488,45 +390,10 @@ function array_create_range(size = 1){
 	return _arr;
 }
 
-/// @description With this function you create a new array where it elements will be all the elements from both given arrays; starting with the first given array
-/// @param {Array} array1					The index of the first array
-/// @param {Array} array2					The index of the second array
-/// @return {Array}								The index of the array
-function array_merge(array1, array2){
-	var _len1 = array_length(array1);
-	var _len2 = array_length(array2);
-	var _arr = array_create(_len1 + _len2);
-	
-	array_copy(_arr, 0, array1, 0, _len1);
-	array_copy(_arr, _len1, array2, 0, _len2);
-	
-	return _arr;
-}
-
-/// @description With this function you create a new array where it elements will be all the elements that exists in both given arrays
-/// @param {Array} array1					The index of the first array
-/// @param {Array} array2					The index of the second array
-/// @return {Array}								The index of the array
-function array_intersection(array1, array2){
-	var _list = ds_list_create();
-	
-	var i = 0; repeat(array_length(array1)){
-		if(array_includes(array2, array1[i]))
-			ds_list_add(_list, array1[i]);	
-		
-		i++;
-	}
-	
-	var _arr = array_from_list(_list);
-	ds_list_destroy(_list);
-	
-	return _arr;
-}
-
 /// @description With this function you create a new array where it elements will be all the elements of the first given array that doesn't exists in the second given array
-/// @param {Array} array1					The index of the first array
-/// @param {Array} array2					The index of the second array
-/// @return {Array}								The index of the array
+/// @param {Array} array1 The index of the first array
+/// @param {Array} array2 The index of the second array
+/// @return {Array} The index of the array
 function array_diff(array1, array2){
 	var _list = ds_list_create();
 	
@@ -543,27 +410,9 @@ function array_diff(array1, array2){
 	return _arr;
 }
 
-/// @description With this function you creates a duplicate-free version from the given array
-/// @param {array} array					The index of the array
-/// @return {array}								The index of the new array
-function array_unique(array){
-	var _list = ds_list_create();
-	
-	var i = 0; repeat(array_length(array)){
-		if(ds_list_find_index(_list, array[i]) == -1) 
-			ds_list_add(_list, array[i]);
-			
-		i++;
-	}
-	
-	var _arr = array_from_list(_list);
-	ds_list_destroy(_list);
-	return _arr;
-}
-
 /// @description With this function you create a new ds_list from an array
-/// @param {array} array					The index of the array
-/// @return {Id.DsList}						The index of the list
+/// @param {array} array The index of the array
+/// @return {Id.DsList} The index of the list
 function array_to_list(array){
 	var _list = ds_list_create();
 	var i = 0; repeat(array_length(array)){
@@ -575,8 +424,8 @@ function array_to_list(array){
 }
 
 /// @description With this function you create an array from a list (ds_list)
-/// @param {Id.DsList} ds_list		The index of the list
-/// @return {array}								The index of the array 
+/// @param {Id.DsList} ds_list The index of the list
+/// @return {array} The index of the array 
 function array_from_list(ds_list){
 	var _len = ds_list_size(ds_list);
 	var array = array_create( _len );	
@@ -590,8 +439,8 @@ function array_from_list(ds_list){
 }
 
 /// @description With this function you create a new ds_stack from an array
-/// @param {array} array					The index of the array
-/// @return {Id.DsStack}					The index of the stack
+/// @param {array} array The index of the array
+/// @return {Id.DsStack} The index of the stack
 function array_to_stack(array){
 	var _stack = ds_stack_create();
 	var i = 0; repeat(array_length(array)){
@@ -602,8 +451,8 @@ function array_to_stack(array){
 }
 
 /// @description With this function you create an array from a stack (ds_stack)
-/// @param {Id.DsStack} ds_stack	The index of the stack
-/// @return {array}								The index of the array
+/// @param {Id.DsStack} ds_stack The index of the stack
+/// @return {array} The index of the array
 function array_from_stack(ds_stack){
 	var _len = ds_stack_size(ds_stack);
 	var _arr = array_create(_len);
@@ -621,8 +470,8 @@ function array_from_stack(ds_stack){
 }
 
 /// @description With this function you create a ds_queue from an array
-/// @param {array} array					The index of the array
-/// @return {Id.DsQueue}					The index of the queue
+/// @param {array} array The index of the array
+/// @return {Id.DsQueue} The index of the queue
 function array_to_queue(array){
 	var _queue = ds_queue_create();
 	var i = 0; repeat(array_length(array)){
@@ -634,10 +483,9 @@ function array_to_queue(array){
 }
 
 /// @description With this function you create a new ds_queue from an array
-/// @param {Id.DsQueue} ds_queue	The Index of the queue
-/// @return {array}								The index of the array 
+/// @param {Id.DsQueue} ds_queue The Index of the queue
+/// @return {array} The index of the array 
 function array_from_queue(ds_queue){
-	
 	var _len = ds_queue_size(ds_queue);
 	var _arr = array_create(_len);
 	var _queue_copy = ds_queue_create();

--- a/scripts/scr_array_utils/scr_array_utils.gml
+++ b/scripts/scr_array_utils/scr_array_utils.gml
@@ -1,6 +1,9 @@
-/// ARRAY UTILS | https://github.com/JeffersonJales/array_utils_gms2
+/* 
+	ARRAY UTILS | https://github.com/JeffersonJales/array_utils_gms2
+	13/12/2022
+*/
 
-/// @description With this function you can shuffle the given array.
+/// @desc With this function you can shuffle the given array.
 /// @param {Array<Any>} array The index of the array to shuffle
 /// @returns {Array<Any>} Re-ordered array 
 function array_shuffle(array){
@@ -19,7 +22,7 @@ function array_shuffle(array){
 	return array;
 }
 
-/// @description With this function you can swap the position of two values from the given array
+/// @desc With this function you can swap the position of two values from the given array
 /// @param {Array<Any>} array The index of the array
 /// @param {Real} index1 The first position to swap
 /// @param {Real} index2 The second position to swap
@@ -31,7 +34,7 @@ function array_swap(array, index1, index2){
 	return array;
 }
 
-/// @description With this function you will copy all the given array to a new one
+/// @desc With this function you will copy all the given array to a new one
 /// @param {Array<Any>} array The index of the array will be cloned
 /// @returns {Array} An new array
 function array_clone(array){
@@ -41,7 +44,7 @@ function array_clone(array){
 	return _arr;
 }
 
-/// @description With this function you can clear the given array with a given value
+/// @desc With this function you can clear the given array with a given value
 /// @param {Array<Any>} array The index of the array to shuffle
 /// @param {Any} value The new value for all array elements
 /// @returns {Array<Any>} A array index
@@ -54,7 +57,7 @@ function array_clear(array, value){
 	return array;
 }
 
-/// @description With this function you can retrieve the value from the given array; It also handles out of bound index (including negative)
+/// @desc With this function you can retrieve the value from the given array; It also handles out of bound index (including negative)
 /// @param {Array<Any>} array The index of the array
 /// @param {Real} index The index of the array to get the value from.
 /// @return {Any} The array index value OR undefined in case the length of the array is zero (0)
@@ -68,7 +71,7 @@ function array_get_ext(array, index){
 	return array[index];
 }
 
-/// @description With this function you can check if the given index is inside of the bounds of the given array
+/// @desc With this function you can check if the given index is inside of the bounds of the given array
 /// @param {Array<Any>} array The index of the array
 /// @param {Real} index The index position to check
 /// @return {Bool} 
@@ -76,14 +79,14 @@ function array_index_inside_bounds(array, index){
 	return index >= 0 && array_length(array) > index; 
 }
 
-/// @description With this function you can check if the given array is empty or not
+/// @desc With this function you can check if the given array is empty or not
 /// @param {Array<Any>} array The index of the array
 /// @return {Bool}					
 function array_empty(array){
 	return array_length(array) == 0;	
 }
 
-/// @description With this function you can retrieve the position of the first entry of the given value on the given array 
+/// @desc With this function you can retrieve the position of the first entry of the given value on the given array 
 /// @param {Array<Any>} array The index of the array
 /// @param {real} value The value to search on the given array
 /// @return {Any} undefined case don't find anything OR the position of the given value on the array (real)
@@ -98,7 +101,7 @@ function array_find_index_simple(array, value){
 	return undefined;
 }
 
-/// @description With this function you can retrieve all positions of the given value on the given array 
+/// @desc With this function you can retrieve all positions of the given value on the given array 
 /// @param {Array<Any>} array The index of the array
 /// @param {real} value The value to search on the given array
 /// @return {Array<Any>} The index of the array 
@@ -116,7 +119,7 @@ function array_find_index_all(array, value){
 	return _arr;
 }
 
-/// @description With this function you can remove all entries of the a given value from a given array 
+/// @desc With this function you can remove all entries of the a given value from a given array 
 /// @param {Array<Any>} array The index of the array
 /// @param {Any} value The value to remove from the array
 /// @return {Array<Any>} The index of the array 
@@ -130,7 +133,7 @@ function array_remove(array, value){
 	return array;
 }
 
-/// @description With this function you can check if the given array have the given value inside of it
+/// @desc With this function you can check if the given array have the given value inside of it
 /// @param {Array<Any>} array The index of the array
 /// @param {Any} value The value to check inside the array
 /// @return {Bool}
@@ -145,7 +148,7 @@ function array_includes(array, value){
 	return false;
 }
 
-/// @description With this function you can check the amount of times the given value appears in the given array
+/// @desc With this function you can check the amount of times the given value appears in the given array
 /// @param {Array<Any>} array The index of the array
 /// @param {Any} value The value to check inside the array
 /// @return {Real}
@@ -159,7 +162,7 @@ function array_includes_amount(array, value){
 	return _amount;
 }
 
-/// @description With this function you can retrieve the maximun value inside of the given array
+/// @desc With this function you can retrieve the maximun value inside of the given array
 /// @param {Array<Real>} array The index of the array
 /// @return {Any} Undefined case array length equals zero OR the max value inside of the array
 function array_get_max_value(array){
@@ -175,7 +178,7 @@ function array_get_max_value(array){
 	return f;
 }
 
-/// @description With this function you can retrieve the minimum value inside of the given array
+/// @desc With this function you can retrieve the minimum value inside of the given array
 /// @param {Array<Real>} array The index of the array 
 /// @return {Any} Undefined case array length equals zero OR the max value inside of the array
 function array_get_min_value(array){
@@ -191,7 +194,7 @@ function array_get_min_value(array){
 	return f;
 }
 
-/// @description With this function you can retrieve a random entry of the given array
+/// @desc With this function you can retrieve a random entry of the given array
 /// @param {Array<Any>} array The index of the array
 /// @return {Any} undefined in case length of the given array is zero OR the value of the a random entry of the given array
 function array_get_random(array){
@@ -201,7 +204,7 @@ function array_get_random(array){
 	return array[ irandom( _len - 1) ];
 }
 
-/// @description With this function you can retrieve the last entry of the given array
+/// @desc With this function you can retrieve the last entry of the given array
 /// @param {Array<Any>} array The index of the array
 /// @return {Any} undefined in case length of the given array is zero OR the value of the last entry given array
 function array_last(array){
@@ -211,7 +214,7 @@ function array_last(array){
 	return array[_len - 1];	
 }
 
-/// @description With this function you can loop through the given array indices executing a given function; The function will be executed for every 
+/// @desc With this function you can loop through the given array indices executing a given function; The function will be executed for every 
 /// entry of the array, receiving the value of the array index as an argument.
 /// @param {Array<Any>} array The index of the array
 /// @param {Function} func The function that will be called to every array entry
@@ -233,7 +236,7 @@ function array_foreach_args(array, func, args){
 	}
 }
 
-/// @description With this function you creates a new array with all elements that pass the test implemented by the provided function.
+/// @desc With this function you creates a new array with all elements that pass the test implemented by the provided function.
 /// @param {Array<Any>} array The index of the array
 /// @param {Function} filter_func Function is a predicate, to test each element of the array. Return a value that coerces to true to keep the element, or to false otherwise.
 /// It will receive the current element being processed in the array and have to return a boolean
@@ -263,7 +266,7 @@ function array_filter_args(array, filter_func, args){
 	return _arr;
 }
 
-/// @description With this function you tests whether at least one element in the array passes the test implemented by the provided function
+/// @desc With this function you tests whether at least one element in the array passes the test implemented by the provided function
 /// @param {Array<Any>} array The index of the array
 /// @param {Function} filter_func Function is a predicate, to test each element of the array. Return a value that coerces to true to keep the element, or to false otherwise.
 /// It will receive the current element being processed in the array and have to return a boolean
@@ -280,7 +283,7 @@ function array_any_args(array, filter_func, args){
 	return array_length(_arr_filter) > 0;
 }
 
-/// @description With this function you tests whether all elements in the array pass the test implemented by the provided function
+/// @desc With this function you tests whether all elements in the array pass the test implemented by the provided function
 /// @param {Array<Any>} array The index of the array
 /// @param {Function} filter_func Function is a predicate, to test each element of the array. Return a value that coerces to true to keep the element, or to false otherwise.
 /// It will receive the current element being processed in the array and have to return a boolean
@@ -297,7 +300,7 @@ function array_all_args(array, filter_func, args){
 	return array_length(array) == array_length(_arr_filter);
 }
 
-/// @description With this function you creates a new array populated with the results of calling a provided function on every element in the calling array.
+/// @desc With this function you creates a new array populated with the results of calling a provided function on every element in the calling array.
 /// @param {Array<Any>} array The index of the array
 /// @param {Function} map_func Function that is called for every element of the given array. Each time it executes, the returned value is added to new array.
 /// @param {Any} args You can parse more arguments to the function, but the first argument of the func will be always the array entry
@@ -325,7 +328,7 @@ function array_map_args(array, map_func, args){
 	return _array_map;
 }
 
-/// @description With this function you can retrieve the all elements of the given array in a string format
+/// @desc With this function you can retrieve the all elements of the given array in a string format
 /// @param {Array<Any>} array The index of the array
 /// @param {String} sep A string symbol to sep every entry
 /// @param {Bool} show_bound An flag to add the array bounds on the final string
@@ -347,7 +350,7 @@ function array_join(array, sep = "", show_bound = false){
 	return _str;
 }
 
-/// @description With this function you create a new array from the given array removing those values: false, zero (0), ""  and undefined 
+/// @desc With this function you create a new array from the given array removing those values: false, zero (0), ""  and undefined 
 /// @param {Array<Any>} array The index of the array
 /// @return {Array} The index of the array
 function array_compact(array){
@@ -358,7 +361,7 @@ function array_compact(array){
 	return array_filter(array, _func);
 }
 
-/// @description With this function you create an array where is length is the given size
+/// @desc With this function you create an array where is length is the given size
 /// Also, all array indices will be initialized with it indice position. 
 /// @param {Real} size The size of the array to create.
 /// @return {Array<Real>, Undefined} The index of the array
@@ -374,7 +377,7 @@ function array_create_range(size = 1){
 	return _arr;
 }
 
-/// @description With this function you create a new array where it elements will be all the elements of the first given array that doesn't exists in the second given array
+/// @desc With this function you create a new array where it elements will be all the elements of the first given array that doesn't exists in the second given array
 /// @param {Array<Any>} array1 The index of the first array
 /// @param {Array<Any>} array2 The index of the second array
 /// @return {Array<Any>} The index of the array
@@ -394,7 +397,7 @@ function array_diff(array1, array2){
 	return _arr;
 }
 
-/// @description With this function you create a new ds_list from an array
+/// @desc With this function you create a new ds_list from an array
 /// @param {Array<Any>} array The index of the array
 /// @return {Id.DsList<Any>} The index of the list
 function array_to_list(array){
@@ -407,7 +410,7 @@ function array_to_list(array){
 	return _list;
 }
 
-/// @description With this function you create an array from a list (ds_list)
+/// @desc With this function you create an array from a list (ds_list)
 /// @param {Id.DsList<Any>} ds_list The index of the list
 /// @return {Array<Any>} The index of the array 
 function array_from_list(ds_list){
@@ -422,7 +425,7 @@ function array_from_list(ds_list){
 	return array;
 }
 
-/// @description With this function you create a new ds_stack from an array
+/// @desc With this function you create a new ds_stack from an array
 /// @param {Array<Any>} array The index of the array
 /// @return {Id.DsStack<Any>} The index of the stack
 function array_to_stack(array){
@@ -434,7 +437,7 @@ function array_to_stack(array){
 	return _stack;
 }
 
-/// @description With this function you create an array from a stack (ds_stack)
+/// @desc With this function you create an array from a stack (ds_stack)
 /// @param {Id.DsStack<Any>} ds_stack The index of the stack
 /// @return {Array<Any>} The index of the array
 function array_from_stack(ds_stack){
@@ -453,7 +456,7 @@ function array_from_stack(ds_stack){
 	return _arr;
 }
 
-/// @description With this function you create a ds_queue from an array
+/// @desc With this function you create a ds_queue from an array
 /// @param {Array<Any>} array The index of the array
 /// @return {Id.DsQueue<Any>} The index of the queue
 function array_to_queue(array){
@@ -466,7 +469,7 @@ function array_to_queue(array){
 	return _queue;
 }
 
-/// @description With this function you create a new ds_queue from an array
+/// @desc With this function you create a new ds_queue from an array
 /// @param {Id.DsQueue<Any>} ds_queue The Index of the queue
 /// @return {Array<Any>} The index of the array 
 function array_from_queue(ds_queue){

--- a/scripts/scr_array_utils/scr_array_utils.yy
+++ b/scripts/scr_array_utils/scr_array_utils.yy
@@ -1,12 +1,11 @@
 {
+  "resourceType": "GMScript",
+  "resourceVersion": "1.0",
+  "name": "scr_array_utils",
   "isDnD": false,
   "isCompatibility": false,
   "parent": {
     "name": "array_wrapper",
     "path": "array_wrapper.yyp",
   },
-  "resourceVersion": "1.0",
-  "name": "scr_array_utils",
-  "tags": [],
-  "resourceType": "GMScript",
 }


### PR DESCRIPTION
### JSDoc Header improved

## Renamed Functions 
array_foreach_ext -> array_foreach_args
array_filter_ext -> array_filter_args
array_map_ext -> array_map_args
array_some_ext -> array_any_args
array_every_ext -> array_all_args
array_find_index -> array_find_index_simple

## Functions removed 

### Without meaningful usage
array_index_convert

### There are similar native functions with the other name
array_some (array_any)
array_every (array_all)
array_merge (array_concat)

### There are similar native functions with the same name
array_unique 
array_reverse
array_intersection
array_foreach
array_map
array_filter
array_reduce